### PR TITLE
configure: bump to version 1.1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ If you are building from a usnic_tools tarball, first run `configure`,
 and then build and install it:
 
 ```sh
-$ tar xf usnic_tools-1.1.0.0.tar.bz2
-$ cd usnic_tools-1.1.0.0
+$ tar xf usnic_tools-1.1.2.0.tar.bz2
+$ cd usnic_tools-1.1.2.0
 
 $ ./configure --prefix=/place/to/install
 # ... lots of output ...

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, Cisco Systems, Inc. All rights reserved.
+# Copyright (c) 2016-2017, Cisco Systems, Inc. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU
@@ -35,7 +35,7 @@
 #
 
 AC_PREREQ([2.57])
-AC_INIT([usnic-tools], [1.1.1.0])
+AC_INIT([usnic-tools], [1.1.2.0])
 
 AC_CONFIG_AUX_DIR(config)
 AM_INIT_AUTOMAKE([foreign no-define 1.11 dist-bzip2])


### PR DESCRIPTION
Changes since v1.1.1.0:

- Add usnic_devinfo.1 man page
- Add -h option to usnic_devinfo

Also update README.md to match.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>