### PR TITLE
configure: bump to version 1.1.2.1a1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@
 #
 
 AC_PREREQ([2.57])
-AC_INIT([usnic-tools], [1.1.2.0])
+AC_INIT([usnic-tools], [1.1.2.1a1])
 
 AC_CONFIG_AUX_DIR(config)
 AM_INIT_AUTOMAKE([foreign no-define 1.11 dist-bzip2])


### PR DESCRIPTION
v1.1.2.0 was just released.  On to the next...

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>